### PR TITLE
Add dlt (data load tool) to Open Source Snowflake Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Active on Twitter and focused on Snowflake - sorted by follower count:
 - [Apache Beam](https://beam.apache.org/documentation/io/built-in/snowflake/)
 - [Apache Superset](https://superset.apache.org/docs/databases/snowflake)
 - [dbt](https://blog.getdbt.com/how-we-configure-snowflake/)
+- [dlt](https://dlthub.com/docs/dlt-ecosystem/destinations/snowflake)
 - [Terraform](https://github.com/chanzuckerberg/terraform-provider-snowflake)
 
 ### UDFs/Procedures


### PR DESCRIPTION
This PR adds dlt (data load tool) to the list of Open Source Snowflake Integrations.

dlt is an open-source Python library for loading data into Snowflake with automatic schema inference and incremental loading. It fits alongside existing entries like Apache Airflow, Apache Beam, and dbt in the Snowflake Integrations section.

- dlt: https://github.com/dlt-hub/dlt
- Snowflake as a destination: https://dlthub.com/docs/dlt-ecosystem/destinations/snowflake